### PR TITLE
feat: implement category - expense & date - expense bar chart in visualization page

### DIFF
--- a/lib/components/category_chart.dart
+++ b/lib/components/category_chart.dart
@@ -1,0 +1,124 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:mexpense/helper/helpers.dart';
+import 'package:mexpense/services/services.dart';
+
+class CategorywiseChart extends StatefulWidget {
+  final LocalExpenseService firestoreService;
+
+  const CategorywiseChart(this.firestoreService, {super.key});
+
+  @override
+  State<CategorywiseChart> createState() => _CategorywiseChartState();
+}
+
+class _CategorywiseChartState extends State<CategorywiseChart> {
+  late Stream<Map<String, double>> _expensesStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _expensesStream = getExpensesStream();
+  }
+
+  Stream<Map<String, double>> getExpensesStream() async* {
+    // DateTime now = DateTime.now();
+    // DateTime fifteenDaysAgo = now.subtract(Duration(days: 15));
+    // DateFormat dateFormat = DateFormat('dd-MMM-yy');
+    Map<String, double> expenses = {};
+
+    for (String category in category) {
+      expenses[category] = 0;
+    }
+
+    yield* widget.firestoreService.getRecords().map((querySnapshot) {
+      final filteredDocs = querySnapshot.docs.where((doc) {
+        return doc.data()['Transaction_type'] == 'Expense';
+      }).toList();
+
+      for (var doc in filteredDocs) {
+        String cate = doc.data()['Category'];
+        double amount = double.tryParse(doc.data()['Amount'].toString()) ?? 0.0;
+        expenses[cate] = (expenses[cate] ?? 0) + amount;
+      }
+
+      return expenses;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Map<String, double>>(
+      stream: _expensesStream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Center(child: CircularProgressIndicator());
+        } else if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return Center(child: Text('No data available'));
+        } else {
+          return BarChart(mainBarChartData(snapshot.data!));
+        }
+      },
+    );
+  }
+
+  BarChartData mainBarChartData(Map<String, double> expenses) {
+    List<BarChartGroupData> barGroups = [];
+
+    for (int i = 0; i < expenses.length; i++) {
+      barGroups.add(
+        BarChartGroupData(
+          x: i,
+          barRods: [
+            BarChartRodData(
+              width: 10,
+              toY: expenses[category[i]]!,
+              gradient: barGradient,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return BarChartData(
+      titlesData: FlTitlesData(
+        show: true,
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            reservedSize: 60,
+            showTitles: true,
+            getTitlesWidget: leftTitles,
+          ),
+        ),
+        rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(showTitles: true, getTitlesWidget: getTitles),
+        ),
+      ),
+      borderData: FlBorderData(show: false),
+      gridData: FlGridData(show: false),
+      barGroups: barGroups,
+    );
+  }
+
+  Widget getTitles(double value, TitleMeta meta) {
+    String text = category[value.toInt()];
+    return SideTitleWidget(
+      meta: meta,
+      space: 2,
+      child: Text(text, style: barChartBottomStyle),
+    );
+  }
+
+  Widget leftTitles(double value, TitleMeta meta) {
+    String text = value.toInt().round().toString();
+    return SideTitleWidget(
+      meta: meta,
+      space: 2,
+      child: Text(text, style: barChartLeftStyle),
+    );
+  }
+}

--- a/lib/components/datewise_chart.dart
+++ b/lib/components/datewise_chart.dart
@@ -1,0 +1,139 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mexpense/helper/helpers.dart';
+import 'package:mexpense/services/services.dart';
+
+class DatewiseChart extends StatefulWidget {
+  final LocalExpenseService firestoreService;
+  final DateTime startdate;
+
+  const DatewiseChart(this.firestoreService, this.startdate, {super.key});
+
+  @override
+  State<DatewiseChart> createState() => _DatewiseChartState();
+}
+
+class _DatewiseChartState extends State<DatewiseChart> {
+  late Stream<Map<String, double>> _expensesStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _expensesStream = getExpensesStream();
+  }
+
+  @override
+  void didUpdateWidget(covariant DatewiseChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.startdate != widget.startdate) {
+      _expensesStream = getExpensesStream();
+    }
+  }
+
+  Stream<Map<String, double>> getExpensesStream() async* {
+    DateTime now = widget.startdate;
+    DateTime fifteenDaysAgo = now.subtract(Duration(days: 15));
+    DateFormat dayFormat = DateFormat('dd');
+    DateFormat dateFormat = DateFormat('dd-MMM-yy');
+    Map<String, double> expenses = {};
+
+    for (int i = 14; i >= 0; i--) {
+      DateTime date = now.subtract(Duration(days: i));
+      expenses[dayFormat.format(date)] = 0;
+    }
+
+    yield* widget.firestoreService.getRecords().map((querySnapshot) {
+      final filteredDocs = querySnapshot.docs.where((doc) {
+        DateTime docDate = dateFormat.parse(doc.data()['date']);
+        return (docDate.isAfter(fifteenDaysAgo) ||
+                docDate.isAtSameMomentAs(fifteenDaysAgo)) &&
+            docDate.isBefore(now.add(Duration(days: 0))) &&
+            doc.data()['Transaction_type'] == 'Expense';
+      }).toList();
+
+      for (var doc in filteredDocs) {
+        DateTime docDate = dateFormat.parse(doc.data()['date']);
+        String day = dayFormat.format(docDate);
+        double amount = double.tryParse(doc.data()['Amount'].toString()) ?? 0.0;
+        expenses[day] = (expenses[day] ?? 0) + amount;
+      }
+
+      return expenses;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<Map<String, double>>(
+      stream: _expensesStream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Center(child: CircularProgressIndicator());
+        } else if (snapshot.hasError) {
+          return Center(child: Text('Error: ${snapshot.error}'));
+        } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+          return Center(child: Text('No data available'));
+        } else {
+          return BarChart(mainBarChartData(snapshot.data!));
+        }
+      },
+    );
+  }
+
+  BarChartData mainBarChartData(Map<String, double> expenses) {
+    List<BarChartGroupData> barGroups = [];
+
+    expenses.forEach((key, value) {
+      int date = int.parse(key);
+      double amount = value;
+      barGroups.add(
+        BarChartGroupData(
+          x: date,
+          barRods: [
+            BarChartRodData(width: 10, toY: amount, gradient: barGradient),
+          ],
+        ),
+      );
+    });
+
+    return BarChartData(
+      titlesData: FlTitlesData(
+        show: true,
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            reservedSize: 60,
+            showTitles: true,
+            getTitlesWidget: leftTitles,
+          ),
+        ),
+        rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(showTitles: true, getTitlesWidget: getTitles),
+        ),
+      ),
+      borderData: FlBorderData(show: false),
+      gridData: FlGridData(show: false),
+      barGroups: barGroups,
+    );
+  }
+
+  Widget getTitles(double value, TitleMeta meta) {
+    String text = value.toInt().toString();
+    return SideTitleWidget(
+      meta: meta,
+      space: 2,
+      child: Text(text, style: barChartBottomStyle),
+    );
+  }
+
+  Widget leftTitles(double value, TitleMeta meta) {
+    String text = value.toInt().round().toString();
+    return SideTitleWidget(
+      meta: meta,
+      space: 2,
+      child: Text(text, style: barChartLeftStyle),
+    );
+  }
+}

--- a/lib/helper/constants.dart
+++ b/lib/helper/constants.dart
@@ -61,8 +61,28 @@ const balTextStyle = TextStyle(
   fontWeight: FontWeight.bold,
 );
 
-const addTextStyle = TextStyle(
-  fontSize: 22,
+const addTextStyle = TextStyle(fontSize: 22, fontWeight: FontWeight.bold);
+
+final barGradient = LinearGradient(
+  colors: [Color(0xFF355C7D), Color(0xFF6C5B7B), Color(0xFFC06C84)],
+  begin: Alignment.bottomCenter,
+  end: Alignment.topCenter,
+);
+
+final barChartLeftStyle = TextStyle(
+  color: Colors.grey,
+  fontWeight: FontWeight.bold,
+  fontSize: 14,
+);
+final barChartBottomStyle = TextStyle(
+  color: Colors.grey,
+  fontWeight: FontWeight.bold,
+  fontSize: 7,
+);
+
+const transactionTextStyle = TextStyle(
+  color: Colors.black,
+  fontSize: 25,
   fontWeight: FontWeight.bold,
 );
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -71,7 +71,7 @@ class _HomescreenState extends State<HomeScreen> {
       ),
       body: index == 0
           ? MainScreen(widget.firestoreService)
-          : Showgraph(widget.firestoreService),
+          : VisualizationScreen(widget.firestoreService),
     );
   }
 }

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -3,3 +3,4 @@ export 'register_screen.dart';
 export 'home_screen.dart';
 export 'main_screen.dart';
 export 'add_expense_screen.dart';
+export 'visualization_screen.dart';

--- a/lib/screens/visualization_screen.dart
+++ b/lib/screens/visualization_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mexpense/components/category_chart.dart';
+import 'package:mexpense/components/datewise_chart.dart';
+import 'package:mexpense/services/services.dart';
+import 'package:mexpense/helper/helpers.dart';
+
+class VisualizationScreen extends StatefulWidget {
+  final LocalExpenseService firestoreService;
+
+  const VisualizationScreen(this.firestoreService, {super.key});
+
+  @override
+  State<VisualizationScreen> createState() => _VisualizationScreenState();
+}
+
+class _VisualizationScreenState extends State<VisualizationScreen> {
+  late DateTime endDate;
+  late DateTime startDate;
+  DateFormat dateFormat = DateFormat('dd MMM yy');
+  String stDate = "";
+  String enDate = "";
+
+  @override
+  void initState() {
+    endDate = DateTime.now();
+    startDate = endDate.subtract(Duration(days: 14));
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    stDate = dateFormat.format(startDate);
+    enDate = dateFormat.format(endDate);
+    return SingleChildScrollView(
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 15),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Date - Expense Bar Chart', style: transactionTextStyle),
+              SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  IconButton(
+                    onPressed: () {
+                      setState(() {
+                        endDate = endDate.subtract(Duration(days: 15));
+                        startDate = startDate.subtract(Duration(days: 15));
+                      });
+                    },
+                    icon: Icon(Icons.keyboard_arrow_left),
+                  ),
+                  Text('$stDate - $enDate'),
+                  IconButton(
+                    onPressed: () {
+                      DateTime temp = DateTime.now();
+                      String newTemp = dateFormat.format(temp);
+                      if (newTemp != enDate) {
+                        setState(() {
+                          endDate = endDate.add(Duration(days: 15));
+                          startDate = startDate.add(Duration(days: 15));
+                        });
+                      }
+
+                      // print(stDate);
+                    },
+                    icon: Icon(Icons.keyboard_arrow_right),
+                  ),
+                ],
+              ),
+              SizedBox(height: 10),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.width,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 5,
+                    vertical: 20,
+                  ),
+                  child: DatewiseChart(widget.firestoreService, endDate),
+                ),
+              ),
+              SizedBox(height: 50),
+              Text('Category - Expense Bar Chart', style: transactionTextStyle),
+              SizedBox(height: 20),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.width,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 5,
+                    vertical: 20,
+                  ),
+                  child: CategorywiseChart(widget.firestoreService),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -81,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   intl: ^0.20.2
   fluttertoast: ^9.0.0
   font_awesome_flutter: ^11.0.0
+  fl_chart: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Expense visualization page shows:
   - category - expense bar chart
   - date - expense bar chart 
   
   
<img width="30%" height="50%" alt="stats2" src="https://github.com/user-attachments/assets/2488d94e-b3b3-461a-86e9-808355e16951" />

Closes #7 